### PR TITLE
feat: handle `if TYPE_CHECKING` block.

### DIFF
--- a/flake8_dunder_all/__init__.py
+++ b/flake8_dunder_all/__init__.py
@@ -159,7 +159,7 @@ class Visitor(ast.NodeVisitor):
 		"""
 
 		if self.use_endlineno:
-			if not node.col_offset and node.end_lineno > self.last_import:  # type: ignore[union-attr]
+			if node.end_lineno > self.last_import:  # type: ignore[union-attr]
 				self.last_import = node.end_lineno  # type: ignore[union-attr]
 		else:
 			if node.lineno > self.last_import:

--- a/flake8_dunder_all/__init__.py
+++ b/flake8_dunder_all/__init__.py
@@ -162,7 +162,7 @@ class Visitor(ast.NodeVisitor):
 			if not node.col_offset and node.end_lineno > self.last_import:  # type: ignore[union-attr]
 				self.last_import = node.end_lineno  # type: ignore[union-attr]
 		else:
-			if not node.col_offset and node.lineno > self.last_import:
+			if node.lineno > self.last_import:
 				self.last_import = node.lineno
 
 	def visit_Import(self, node: ast.Import) -> None:
@@ -184,6 +184,21 @@ class Visitor(ast.NodeVisitor):
 
 		# Don't generic visit
 		self.handle_import(node)
+
+	def visit_If(self, node: ast.If) -> None:
+		"""
+		Visit an if statement and check if it's for `TYPE_CHECKING`.
+
+		:param node: The node being visited.
+		"""
+		# Check if the condition is checking for TYPE_CHECKING
+		if isinstance(node.test, ast.Name) and node.test.id == "TYPE_CHECKING":
+			# Process the body of the if statement for any import statements
+			for body_node in node.body:
+				if isinstance(body_node, (ast.Import, ast.ImportFrom)):
+					self.handle_import(body_node)
+		# Continue visiting other nodes
+		self.generic_visit(node)
 
 
 class Plugin:

--- a/tests/common.py
+++ b/tests/common.py
@@ -145,3 +145,12 @@ import foo
 
 asyn def a_function): ...
 '''
+
+if_type_checking_source = '''
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+	from foo import bar
+
+def a_function(): ...
+'''

--- a/tests/common.py
+++ b/tests/common.py
@@ -139,6 +139,31 @@ testing_source_l = '''
 def a_function(): ...
 '''
 
+testing_source_m = '''
+"""a docstring"""
+
+from foo import bar
+
+if False:
+	from x import y
+
+def a_function():
+	from hello import world
+'''
+
+testing_source_n = '''
+"""a docstring"""
+
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING or sys.version_info < (3, 9):
+	from x import y
+
+def a_function():
+	from hello import world
+'''
+
 mangled_source = '''
 """a docstring
 import foo
@@ -146,11 +171,11 @@ import foo
 asyn def a_function): ...
 '''
 
-if_type_checking_source = '''
+if_type_checking_source = """
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
 	from foo import bar
 
 def a_function(): ...
-'''
+"""

--- a/tests/test_flake8_dunder_all.py
+++ b/tests/test_flake8_dunder_all.py
@@ -24,7 +24,9 @@ from common import (
 		testing_source_i,
 		testing_source_j,
 		testing_source_k,
-		testing_source_l
+		testing_source_l,
+		testing_source_m,
+		testing_source_n
 		)
 from consolekit.terminal_colours import Fore
 from domdf_python_tools.paths import PathPlus
@@ -84,6 +86,7 @@ def test_plugin(source: str, expects: Set[str]):
 				pytest.param(testing_source_h, [], False, 1, id="from import"),
 				pytest.param(testing_source_i, ["a_function"], False, 3, id="lots of lines"),
 				pytest.param(testing_source_j, ["a_function"], False, 2, id="multiline import"),
+				pytest.param(testing_source_m, ["a_function"], False, 7, id="if False"),
 				pytest.param(if_type_checking_source, ["a_function"], False, 5, id="if TYPE_CHECKING:"),
 				]
 		)
@@ -120,6 +123,8 @@ def test_visitor(source: str, members: List[str], found_all: bool, last_import: 
 				pytest.param(testing_source_h, [], False, 1, id="from import"),
 				pytest.param(testing_source_i, ["a_function"], False, 3, id="lots of lines"),
 				pytest.param(testing_source_j, ["a_function"], False, 14, id="multiline import"),
+				pytest.param(testing_source_m, ["a_function"], False, 7, id="if False"),
+				pytest.param(if_type_checking_source, ["a_function"], False, 5, id="if TYPE_CHECKING:"),
 				]
 		)
 def test_visitor_endlineno(source: str, members: List[str], found_all: bool, last_import: int):
@@ -153,6 +158,8 @@ def test_visitor_endlineno(source: str, members: List[str], found_all: bool, las
 				pytest.param(testing_source_i, [], 1, id="lots of lines"),
 				pytest.param(testing_source_k, [], 0, id="overload"),
 				pytest.param(testing_source_l, [], 0, id="typing.overload"),
+				pytest.param(testing_source_m, [], 1, id="if False"),
+				pytest.param(testing_source_n, [], 1, id="if TYPE_CHECKING"),
 				]
 		)
 def test_check_and_add_all(
@@ -198,6 +205,8 @@ def test_check_and_add_all(
 				pytest.param(testing_source_i, [], 1, id="lots of lines"),
 				pytest.param(testing_source_k, [], 0, id="overload"),
 				pytest.param(testing_source_l, [], 0, id="typing.overload"),
+				pytest.param(testing_source_m, [], 1, id="if False"),
+				pytest.param(testing_source_n, [], 1, id="if TYPE_CHECKING"),
 				]
 		)
 def test_check_and_add_all_tuples(
@@ -231,6 +240,8 @@ def test_check_and_add_all_tuples(
 				pytest.param(testing_source_g, ["a_function"], 1, id="async function no __all__"),
 				pytest.param(testing_source_h, [], 0, id="from import"),
 				pytest.param(testing_source_i, [], 1, id="lots of lines"),
+				pytest.param(testing_source_m, [], 1, id="if False"),
+				pytest.param(testing_source_n, [], 1, id="if TYPE_CHECKING"),
 				]
 		)
 def test_check_and_add_all_single_quotes(tmp_pathplus: PathPlus, source: str, members: List[str], ret: int):

--- a/tests/test_flake8_dunder_all.py
+++ b/tests/test_flake8_dunder_all.py
@@ -8,6 +8,7 @@ from typing import List, Set
 import pytest
 from coincidence.regressions import AdvancedFileRegressionFixture
 from common import (
+		if_type_checking_source,
 		mangled_source,
 		results,
 		testing_source_a,
@@ -83,6 +84,7 @@ def test_plugin(source: str, expects: Set[str]):
 				pytest.param(testing_source_h, [], False, 1, id="from import"),
 				pytest.param(testing_source_i, ["a_function"], False, 3, id="lots of lines"),
 				pytest.param(testing_source_j, ["a_function"], False, 2, id="multiline import"),
+				pytest.param(if_type_checking_source, ["a_function"], False, 5, id="if TYPE_CHECKING:"),
 				]
 		)
 def test_visitor(source: str, members: List[str], found_all: bool, last_import: int):

--- a/tests/test_flake8_dunder_all_/test_check_and_add_all_if_False_._py_
+++ b/tests/test_flake8_dunder_all_/test_check_and_add_all_if_False_._py_
@@ -1,0 +1,13 @@
+
+"""a docstring"""
+
+from foo import bar
+
+if False:
+	from x import y
+
+__all__ = ["a_function"]
+
+
+def a_function():
+	from hello import world

--- a/tests/test_flake8_dunder_all_/test_check_and_add_all_if_TYPE_CHECKING_._py_
+++ b/tests/test_flake8_dunder_all_/test_check_and_add_all_if_TYPE_CHECKING_._py_
@@ -1,0 +1,14 @@
+
+"""a docstring"""
+
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING or sys.version_info < (3, 9):
+	from x import y
+
+__all__ = ["a_function"]
+
+
+def a_function():
+	from hello import world

--- a/tests/test_flake8_dunder_all_/test_check_and_add_all_tuples_if_False_._py_
+++ b/tests/test_flake8_dunder_all_/test_check_and_add_all_tuples_if_False_._py_
@@ -1,0 +1,13 @@
+
+"""a docstring"""
+
+from foo import bar
+
+if False:
+	from x import y
+
+__all__ = ("a_function", )
+
+
+def a_function():
+	from hello import world

--- a/tests/test_flake8_dunder_all_/test_check_and_add_all_tuples_if_TYPE_CHECKING_._py_
+++ b/tests/test_flake8_dunder_all_/test_check_and_add_all_tuples_if_TYPE_CHECKING_._py_
@@ -1,0 +1,14 @@
+
+"""a docstring"""
+
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING or sys.version_info < (3, 9):
+	from x import y
+
+__all__ = ("a_function", )
+
+
+def a_function():
+	from hello import world


### PR DESCRIPTION
We are experiencing an issue where the `__all__` declaration gets positioned between runtime and type checking imports. E.g., 

![image](https://github.com/python-formate/flake8-dunder-all/assets/20659309/1f7983f0-0087-47ca-b9a2-3d138d149525)

So I've slapped this together as a PoC.

The PR updates visitor so that the `last_import` is updated for import lines that occur within an `if TYPE_CHECKING` block.

I've not done any ast stuff before, so don't really know if what I've added here is a good way to go about it, also how far I should go with tests. Any advice appreciated.